### PR TITLE
fix(tianji): new url for tianji

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/hei-templates/hei-synd-thesis)
 ![GitHub Release](https://img.shields.io/github/v/release/hei-templates/hei-synd-thesis)
-![](https://tianji.tschinz.duckdns.org/telemetry/clnzoxcy10001vy2ohi4obbi0/cm7hhbe65003cru047eqabmpg.gif)
+![](https://tianji.zahno.dev/telemetry/clnzoxcy10001vy2ohi4obbi0/cm7hhbe65003cru047eqabmpg.gif)
 <h1 align="center">
   <br>
   <img src="https://github.com/hei-templates/hei-synd-logos/blob/5a15ff1e95e012e53c34580554a4834cdec05d01/hei-en.svg" alt="HEI-Vs Logo" width="350">


### PR DESCRIPTION
Since we exhausted the free tianji tier, it was moved.