### PR TITLE
fix(ci): remove typst version to use always latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,6 @@ jobs:
 
       - name: Setup Typst
         uses: typst-community/setup-typst@v4
-        with:
-          typst-version: 0.13.0
 
       - name: Install Package
         env:


### PR DESCRIPTION
The package should always compile on the latest typst version. So the CI use the latest Typst compiler version to build for a release