### PR TITLE
typo(metadata): removed extra parenthesis

### DIFF
--- a/template/metadata.typ
+++ b/template/metadata.typ
@@ -118,7 +118,6 @@
   topright: image("/resources/img/logos/hesso-logo.svg", width: 4cm),
   bottomleft: image("/resources/img/logos/hevs-pictogram.svg", width: 4cm),
   bottomright: image("/resources/img/logos/swiss_universities-valais-excellence-logo.svg", width: 5cm),
-  )
 )
 
 //-------------------------------------


### PR DESCRIPTION
Hi!

There is an extra parenthesis that has no reason to be here. Just removed it.

BR,
Terrazed